### PR TITLE
chore: added github workflows to check commit and PR

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -20,11 +20,15 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: Lint
-              run: yarn lint
-            - name: Installation & Build Package
+            - name: Installation
               # installation already takes care of calling prepare which calls build
               # for the sdk package
-              run: yarn --frozen-lockfile && yarn build
+              run: yarn --frozen-lockfile
+            - name: Lint
+              run: yarn lint
+            - name: Build Package
+              # installation already takes care of calling prepare which calls build
+              # for the sdk package
+              run: yarn build
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,30 @@
+name: Lint and Build Package
+
+on:
+    pull_request:
+        branches:
+            - develop
+            - main
+            - "v[0-9]+.[0-9]+.[0-9]+*beta*"
+        types: [opened, synchronize]
+
+jobs:
+    check_pr:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  # Disabling shallow clone is recommended for improving relevancy of reporting
+                  fetch-depth: 0
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Lint
+              run: yarn lint
+            - name: Installation & Build Package
+              # installation already takes care of calling prepare which calls build
+              # for the sdk package
+              run: yarn --frozen-lockfile && yarn build
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: "Lint PR title"
+
+on:
+    pull_request:
+        branches:
+            - develop
+            - "v[0-9]+.[0-9]+.[0-9]+"
+        types: [opened, edited, synchronize]
+
+jobs:
+    lint_pr_title:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: deepakputhraya/action-pr-title@v1.0.2
+              with:
+                  regex: '^(\w*)(?:\((.*)\))?: (.*)$'


### PR DESCRIPTION
This PR focuses on adding lint_pr_title and check_pr workflows which are used to check for conventional commits and the PR quality through lint and build checks.