### PR TITLE
feat: added authenticated client details view on header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { PageHeader, Row, Col, Typography, Switch } from "antd";
+import { ClientType } from "../../types";
 
 export type HeaderType = {
-    darkMode: boolean;
-    setDarkMode: (data: boolean) => void;
+    viewClient: boolean;
+    setViewClient: (checked: boolean) => void;
 };
 
 const Header = (props: HeaderType) => {
-    const { darkMode, setDarkMode } = props;
+    const { viewClient, setViewClient } = props;
     return (
         <PageHeader style={{ backgroundColor: "darkgray" }}>
             <Row>
                 <Col>
                     <Typography style={{ color: "white" }}>
-                        Dark Mode
+                        View Authenticated Client
                     </Typography>
                 </Col>
                 <Col style={{ marginLeft: 20 }}>
                     <Switch
-                        checked={darkMode}
+                        checked={viewClient}
                         onChange={(checked) => {
-                            setDarkMode(checked);
+                            setViewClient(checked);
                         }}
                     />
                 </Col>

--- a/src/screens/ChannelList.tsx
+++ b/src/screens/ChannelList.tsx
@@ -36,12 +36,13 @@ const ChannelListScreen = (props: ChannelListScreenType) => {
                             onClick={() => {
                                 setSelectedChannelId(item.id);
                             }}
+                            style={{ marginLeft: 20, marginRight: 20 }}
                         >
                             <List.Item.Meta
                                 avatar={
                                     <Avatar
                                         src={item.image}
-                                        style={{ margin: 10 }}
+                                        style={{ marginTop: 10 }}
                                     />
                                 }
                                 title={item.title}

--- a/src/screens/MessageList.tsx
+++ b/src/screens/MessageList.tsx
@@ -38,6 +38,7 @@ const MessageListScreen = (props: MessageListScreenType) => {
                                 onClick={() => {
                                     setSelectedMessageId(item.id);
                                 }}
+                                style={{ marginLeft: 20, marginRight: 20 }}
                             >
                                 <Comment
                                     author={item.userName}

--- a/src/screens/ThreadList.tsx
+++ b/src/screens/ThreadList.tsx
@@ -38,6 +38,7 @@ const ThreadMessageListScreen = (props: ThreadListScreenType) => {
                                 onClick={() => {
                                     setSelectedThreadMessageId(item.id);
                                 }}
+                                style={{ marginLeft: 20, marginRight: 20 }}
                             >
                                 <Comment
                                     author={item.userName}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,10 @@ export type ChannelType = {
     >;
 };
 
+export type ClientType = {
+    name: string;
+};
+
 export type MessageType = {
     created_at: string;
     html: string;
@@ -28,6 +32,7 @@ export type ThreadType = MessageType;
 
 export type Events = {
     Channels: ChannelType[];
+    Client: ClientType;
     Messages: MessageType[];
     ThreadList: ThreadType[];
 };


### PR DESCRIPTION
This PR focuses on adding authenticated client's view on the desktop plugin. Users can toggle the view by clicking the switch and all the details about the authenticated view will be visible.